### PR TITLE
Allow setting the web return value to null

### DIFF
--- a/lib/flutter_window_close.dart
+++ b/lib/flutter_window_close.dart
@@ -86,7 +86,7 @@ class FlutterWindowClose {
 
   /// Sets a return value when the current window or tab is being closed
   /// when your app is running in Flutter Web.
-  static void setWebReturnValue(String returnValue) {
+  static void setWebReturnValue(String? returnValue) {
     if (!kIsWeb) throw Exception('The method only works in Flutter Web.');
     _channel.invokeMethod('setWebReturnValue', returnValue);
   }

--- a/lib/flutter_window_close_web.dart
+++ b/lib/flutter_window_close_web.dart
@@ -25,7 +25,9 @@ class FlutterWindowClosePluginWeb {
   FlutterWindowClosePluginWeb() {
     html.window.onBeforeUnload.listen((event) {
       if (event is html.BeforeUnloadEvent) {
-        event.returnValue = _returnValue;
+        if (_returnValue != null) {
+          event.returnValue = _returnValue;
+        }
       }
     });
   }


### PR DESCRIPTION
The plugin currently doesn't seem to allow for "removing" the web return value after it's set.

For my use case, I wanted to set the web return value to something while the user has pending (unsaved) changes to a document. When they have saved their changes, I want to set the web return value back to nothing so the browser doesn't prompt the user when navigating away from the site.

This pull request allows the user to set the web return value to 'null' which will prevent the web event's return value from being set.