### PR TITLE
linux: emit destroy from separate detached thread

### DIFF
--- a/linux/flutter_window_close_plugin.cc
+++ b/linux/flutter_window_close_plugin.cc
@@ -5,6 +5,7 @@
 #include <sys/utsname.h>
 
 #include <cstring>
+#include <thread>
 
 #define FLUTTER_WINDOW_CLOSE_PLUGIN(obj)                                       \
     (G_TYPE_CHECK_INSTANCE_CAST((obj), flutter_window_close_plugin_get_type(), \
@@ -35,7 +36,9 @@ static void flutter_window_close_plugin_handle_method_call(
         response
             = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
         fl_method_call_respond(method_call, response, nullptr);
-        gtk_widget_destroy((GtkWidget*)self->widget);
+        std::thread([=]() {
+            g_signal_emit_by_name(G_OBJECT((GtkWindow*)self->widget), "destroy");
+        }).detach();
     } else {
         g_autoptr(FlMethodResponse) response = nullptr;
         response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());


### PR DESCRIPTION
Thanks for working on this plugin!
Real life saver.

I was experiencing a freeze in my application due to this. And, only way to close the app afterwards was sending a `SIGKILL`. This however, fixes it.

I think this causes some deadlock (or race condition?) with platform channel call from Flutter.
