### PR TITLE
[windows] Use existing window proc delegation & HWND retrieval APIs from Flutter

### DIFF
--- a/lib/flutter_window_close.dart
+++ b/lib/flutter_window_close.dart
@@ -84,6 +84,11 @@ class FlutterWindowClose {
     _channel.invokeMethod('closeWindow');
   }
 
+  static void destroyWindow() {
+    if (kIsWeb) throw Exception('The method does not work in Flutter Web.');
+    _channel.invokeMethod('destroyWindow');
+  }
+
   /// Sets a return value when the current window or tab is being closed
   /// when your app is running in Flutter Web.
   static void setWebReturnValue(String? returnValue) {

--- a/windows/.clang-format
+++ b/windows/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -15,7 +15,12 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_link_libraries(
+  ${PLUGIN_NAME} PRIVATE
+  flutter
+  flutter_wrapper_plugin
+  "comctl32.lib"
+)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(flutter_window_close_bundled_libraries

--- a/windows/flutter_window_close_plugin.cpp
+++ b/windows/flutter_window_close_plugin.cpp
@@ -65,7 +65,8 @@ FlutterWindowClosePlugin::FlutterWindowClosePlugin(
 
 FlutterWindowClosePlugin::~FlutterWindowClosePlugin() {
   if (window_proc_delegate_id_ != -1) {
-    registrar_->UnregisterTopLevelWindowProcDelegate(window_proc_delegate_id_);
+    registrar_->UnregisterTopLevelWindowProcDelegate(
+        static_cast<int32_t>(window_proc_delegate_id_));
   }
 }
 


### PR DESCRIPTION
- feat: expose `FlutterWindowClose.destroyWindow` for customized usage.
- fix: use `flutter::PluginRegistrarWindows::RegisterTopLevelWindowProcDelegate` for proc delegation & improve `HWND` retrieval.
  - Refactored Windows implementation use make use of `flutter::PluginRegistrarWindows::RegisterTopLevelWindowProcDelegate` instead of changing GWLP_WNDPROC. This gives other plugins opportunity to delegate/listen to window messages as-well.
  - Replaced `GetActiveWindow` with public API present in Flutter already. `GetActiveWindow` can result in unpredicted behaviors.
  - Improved code structure & followed [Google Style Guide for C++](https://google.github.io/styleguide/cppguide.html).
  
https://github.com/zonble/flutter_window_close/blob/79e358db9e1edaa9dc147a7e31d73b0b3ba02cdb/windows/flutter_window_close_plugin.cpp#L73-L75