### PR TITLE
Web: Call preventDefault only when the plugin was enabled explicitly by setWebReturnValue

### DIFF
--- a/lib/flutter_window_close_web.dart
+++ b/lib/flutter_window_close_web.dart
@@ -28,8 +28,8 @@ class FlutterWindowClosePluginWeb {
       (JSAny event) {
         if (event.isA<BeforeUnloadEvent>()) {
           final unloadEvent = event as BeforeUnloadEvent;
-          unloadEvent.preventDefault();
           if (_returnValue != null) {
+            unloadEvent.preventDefault();
             unloadEvent.returnValue = _returnValue!;
           }
         }


### PR DESCRIPTION
It was not possible to disable the behavior at the moment. Browsers understanding preventDefault() would always show the dialog as long as the plugin is enabled.

Broken in commit 166df017c8d050e5dcb58a92e189ce177dde6477.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed web platform window close and reload behavior to more precisely handle when default browser unload prevention should be applied, improving reliability of these operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->