### PR TITLE
Throw Dart errors when calling a method on an unsupported platform

### DIFF
--- a/lib/flutter_window_close.dart
+++ b/lib/flutter_window_close.dart
@@ -14,6 +14,8 @@ class FlutterWindowClose {
   static MethodChannel? _notificationChannel;
   static const MethodChannel _channel = MethodChannel('flutter_window_close');
 
+  static UnsupportedError _webUnsupported() => UnsupportedError('This method must not be called on the web.');
+
   static Future<void> _initIfRequired() async {
     if (_notificationChannel != null) {
       return;
@@ -77,7 +79,7 @@ class FlutterWindowClose {
   /// The method does not support Flutter Web.
   static Future<void> setWindowShouldCloseHandler(
       Future<bool> Function()? handler) async {
-    if (kIsWeb) throw Exception('The method does not work in Flutter Web.');
+    if (kIsWeb) throw _webUnsupported();
     _onWindowShouldClose = handler;
     await _initIfRequired();
   }
@@ -90,13 +92,13 @@ class FlutterWindowClose {
   /// - On Linux, it calls [gtk_window_close](https://gnome.pages.gitlab.gnome.org/gtk/gtk4/method.Window.close.html)
   /// - The method does not support Flutter Web.
   static Future<void> closeWindow() async {
-    if (kIsWeb) throw Exception('The method does not work in Flutter Web.');
+    if (kIsWeb) throw _webUnsupported();
     await _initIfRequired();
     await _channel.invokeMethod('closeWindow');
   }
 
   static Future<void> destroyWindow() async {
-    if (kIsWeb) throw Exception('The method does not work in Flutter Web.');
+    if (kIsWeb) throw _webUnsupported();
     await _initIfRequired();
     await _channel.invokeMethod('destroyWindow');
   }
@@ -104,7 +106,7 @@ class FlutterWindowClose {
   /// Sets a return value when the current window or tab is being closed
   /// when your app is running in Flutter Web.
   static Future<void> setWebReturnValue(String? returnValue) async {
-    if (!kIsWeb) throw Exception('The method only works in Flutter Web.');
+    if (!kIsWeb) throw UnsupportedError('The method must not be called on non-web platforms.');
     await _channel.invokeMethod('setWebReturnValue', returnValue);
   }
 }


### PR DESCRIPTION
Some methods are not intended to be called on the web, at least according to the doc comments:

```dart
/// ...
/// - The method does not support Flutter Web.
static Future<void> closeWindow()
```

So the methods delegate responsibility for checking whether this is a web platform to the consumer (by design). Meaning that if the programmer called `closeWindow()` without checking the web platform, it's considered a programming error, not a recoverable failure.

In Dart at least, [`Error`s are not intended to be caught](https://api.dart.dev/dart-core/Exception-class.html); they are programming bugs that should be addressed rather than handled.

The Dart documentation also says:

> Errors differ from Exceptions in that Errors can be analyzed and prevented prior to runtime. It should almost never be necessary to catch an error at runtime.

To provide enhanced semantic and work with tools like Sentry, Firebase Crashlytics, the code should throw an `Error` such as `UnsupportedError`, to indicate a bug (e.g., calling `destroyWindow()` on all platforms without checking for web via`kIsWeb` constant).

**Related Dart lints:** (both are applied in flutter/packages repo)

- [only_throw_errors](https://dart.dev/tools/linter-rules/only_throw_errors)
- [avoid_catching_errors](https://dart.dev/tools/linter-rules/avoid_catching_errors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified error handling for unsupported window operations by introducing a shared error handler and replacing generic exceptions with explicit, descriptive error messages for platform-incompatible API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->